### PR TITLE
Add new option: --sharenotify "command"

### DIFF
--- a/mining_libs/share_stats.py
+++ b/mining_libs/share_stats.py
@@ -1,0 +1,71 @@
+import time
+import stratum.logger
+import subprocess
+
+log = stratum.logger.get_logger('proxy')
+
+class ShareStats(object):
+    max_job_time = 600
+    
+    def __init__(self,register_cmd='echo [%t] %w %j/%d >> /tmp/sharestats.log'):
+        self.shares = {}
+        self.register_cmd = register_cmd
+    
+    def setCMD(self,cmd):
+        self.register_cmd = cmd
+    
+    def resetJobs(self):
+        self.shares = {}
+
+    def addJob(self, job_id, worker_name):
+        if not job_id in self.shares:
+            self.shares[job_id] = [worker_name,time.time()]
+
+    def registerJob(self,job_id,dif):
+        if job_id in self.shares:
+            job = self.shares[job_id]
+            self._execute_cmd(job_id,job[0],job[1],dif)
+            self.delJob(job_id)
+            return True
+        else: return False
+
+    def delJob(self,job_id):
+        try:
+            del self.shares[job_id]
+            return True
+        except:
+            pass
+            return False
+        
+    def listJobs(self):
+        return self.shares.keys()
+
+    def getWorker(self,job_id):
+        return self.shares[job_id][0]
+
+    def getJobByWorker(self,worker_name):
+        jobs = []
+        for job in self.shares.keys():
+            if self.shares.keys[job][0] == worker_name:
+                jobs.append(self.shares.keys[job][0])
+        return jobs
+    
+    def cleanJobs(self):
+        current_time = time.time()
+        for job in self.shares.keys():
+            if current_time - self.shares.keys()[job][1] > max_job_time:
+                del self.shares[job]
+            
+    def __str__(self):
+        return self.shares.__str__()
+    
+    def _execute_cmd(self, job_id, worker_name, init_time,dif):
+        if self.register_cmd:
+            cmd = self.register_cmd.replace('%j', job_id)
+            cmd = cmd.replace('%w', worker_name)
+            cmd = cmd.replace('%t', str(init_time))
+            cmd = cmd.replace('%d', str(dif))
+            log.info("Executing sharenotify command: %s" %cmd)
+            subprocess.Popen(cmd, shell=True)
+        
+        

--- a/mining_proxy.py
+++ b/mining_proxy.py
@@ -38,6 +38,7 @@ def parse_args():
     parser.add_argument('-cp', '--custom-password', dest='custom_password', type=str, help='Use this password for submitting shares')
     parser.add_argument('--old-target', dest='old_target', action='store_true', help='Provides backward compatible targets for some deprecated getwork miners.')    
     parser.add_argument('--blocknotify', dest='blocknotify_cmd', type=str, default='', help='Execute command when the best block changes (%%s in BLOCKNOTIFY_CMD is replaced by block hash)')
+    parser.add_argument('--sharenotify', dest='sharestats_cmd', type=str, default=None, help='Execute command when a share is accepted (%%w=worker_name %%j=job_id %%t=init_time %%d=difficulty are replaced in the command)')
     parser.add_argument('--socks', dest='proxy', type=str, default='', help='Use socks5 proxy for upstream Stratum connection, specify as host:port')
     parser.add_argument('--tor', dest='tor', action='store_true', help='Configure proxy to mine over Tor (requires Tor running on local machine)')
     parser.add_argument('-t', '--test', dest='test', action='store_true', help='Run performance test on startup')    
@@ -254,6 +255,7 @@ def main(args):
     if args.stratum_port > 0:
         stratum_listener.StratumProxyService._set_upstream_factory(f)
         stratum_listener.StratumProxyService._set_custom_user(args.custom_user, args.custom_password)
+        stratum_listener.StratumProxyService._set_sharestats_cmd(args.sharestats_cmd)
         reactor.listenTCP(args.stratum_port, SocketTransportFactory(debug=False, event_handler=ServiceEventHandler))
 
     # Setup multicast responder


### PR DESCRIPTION
  Execute command when a share is accepted
  (%%w=worker_name %%j=job_id %%t=init_time %%d=difficulty are replaced in the command)

Example: --sharenotify "echo [%t] %w %j/%d >> /var/log/shares.log"

If "-cu" option is specified, the original worker name is preserved

It might be used to insert the share statistics (worker and difficulty) into a database.
  --sharenotify "sh my_sql_script.sh %w %d"

Or many other things. It is also possible to calculate the KH/s of all proxy miner clients.

The implementation probably would need a couple more of eyes!  It is the first time I read this code.
