### PR TITLE
Make midstatec extension module installable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.pyc
+build
+distribute*
+*egg-info*
 debian/files
 debian/*/
 debian/*.debhelper*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+debian/files
+debian/*/
+debian/*.debhelper*
+debian/*.substvars

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Installation on Windows
 2. Open downloaded file. It will open console window. Using default settings, proxy connects to Slush's pool interface
 3. If you want to connect to another pool or change other proxy settings, type "mining_proxy.exe --help" in console window.
 
-Installation on Linux
----------------------
+Installation on Linux - local hierarchy
+---------------------------------------
 
 1. Download TGZ file from https://github.com/slush0/stratum-mining-proxy/tarball/master
 2. Unpack it by typing "tar xf slush0-stratum-mining_proxy*.tar.gz"
@@ -22,6 +22,15 @@ Installation on Linux
 4. You can start the proxy by typing "./mining_proxy.py" in the terminal window. Using default settings,
 proxy connects to Slush's pool interface.
 5. If you want to connect to another pool or change other proxy settings, type "mining_proxy.py --help".
+
+Packaging for Debian
+--------------------
+
+1. Install devscripts, debhelper, pbuilder.
+2. Download and unpack a tarball or clone this repository. Enter the unpacked/cloned direcotry.
+3. Type "debuild-pbuilder -b -uc -us". You will be asked your password for sudo command. If you're a sudoer, skip to the last step.
+4. If you're not a sudoer, an error will occur. Do `apt-get -f install' as root to correct the situation and call "debuild -b -uc -us".
+5. A .deb package will be generated in parent directory. Use it to install stratum-mining-proxy on a Debian compatible system.
 
 Installation on Mac
 -------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+stratum-mining-proxy (1.5.7-1) unstable; urgency=low
+
+  * Make midstatec module installable in debian.
+
+ -- Jacek Krysztofik <jacek.krysztofik@infinite.pl>  Fri, 9 May 2014 23:59:59 +0200
+
 stratum-mining-proxy (1.5.6-1) unstable; urgency=low
 
   * Add CUSTOM_USER and SCRYPT_TARGET options in default file

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+stratum-mining-proxy (1.5.9-2) unstable; urgency=low
+
+  * Add process name.
+  * Exit after n unsuccessful connection attempts.
+
+ -- Jacek Krysztofik <jacek.krysztofik@infinite.pl>  Sat, 14 Jun 2014 13:37:11 +0200
+
 stratum-mining-proxy (1.5.7-1) unstable; urgency=low
 
   * Make midstatec module installable in debian.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+stratum-mining-proxy (1.5.10-1) unstable; urgency=low
+
+  * Add option for extranonce2 randomization.
+
+ -- Jacek Krysztofik <jacek.krysztofik@infinite.pl>  Wed, 23 Jul 2014 13:37:11 +0200
+
 stratum-mining-proxy (1.5.9-2) unstable; urgency=low
 
   * Add process name.

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,13 @@ Source: stratum-mining-proxy
 Maintainer: Corey Ralph <corey@trellian.com>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3), debhelper (>= 7), python-support (>= 0.8.4)
+Build-Depends: python-setuptools (>= 0.6b3), debhelper (>= 7), python-support (>= 0.8.4), libssl-dev, python-dev
 Standards-Version: 3.8.4
 XS-Python-Version: current
 
 Package: stratum-mining-proxy
-Architecture: all
+Architecture: i386 amd64
 Depends: ${misc:Depends}, ${python:Depends}, python-stratum, python-twisted-web, python-ecdsa, python-argparse
 XB-Python-Version: ${python:Versions}
 Provides: ${python:Provides}
 Description: Getwork-compatible proxy for Stratum mining pools
-

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ XS-Python-Version: current
 
 Package: stratum-mining-proxy
 Architecture: i386 amd64
-Depends: ${misc:Depends}, ${python:Depends}, python-stratum, python-twisted-web, python-ecdsa, python-argparse
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}, python-stratum, python-twisted-web, python-ecdsa, python-argparse, python-setproctitle
 XB-Python-Version: ${python:Versions}
 Provides: ${python:Provides}
 Description: Getwork-compatible proxy for Stratum mining pools

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,8 @@ unexport CXXFLAGS
 unexport FFLAGS
 unexport LDFLAGS
 
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
 #exports specified using stdeb Setup-Env-Vars:
 #export DH_OPTIONS=--buildsystem=python_distutils
 

--- a/mining_libs/jobs.py
+++ b/mining_libs/jobs.py
@@ -15,7 +15,7 @@ log = stratum.logger.get_logger('proxy')
 from midstate import calculateMidstate as __unusedimport
 
 try:
-    from midstatec.midstatec import test as midstateTest, midstate as calculateMidstate
+    from midstatec import test as midstateTest, midstate as calculateMidstate
     if not midstateTest():
         log.warning("midstate library didn't passed self test!")
         raise ImportError("midstatec not usable")

--- a/mining_libs/jobs.py
+++ b/mining_libs/jobs.py
@@ -15,18 +15,25 @@ log = stratum.logger.get_logger('proxy')
 from midstate import calculateMidstate as __unusedimport
 
 try:
-    from midstatec import test as midstateTest, midstate as calculateMidstate
-    if not midstateTest():
-        log.warning("midstate library didn't passed self test!")
-        raise ImportError("midstatec not usable")
-    log.info("Using C extension for midstate speedup. Good!")
+  from midstatec import test as midstateTest, midstate as calculateMidstate
+  if not midstateTest():
+    log.warning("midstate library didn't pass self test!")
+    raise ImportError("midstatec not usable")
+  log.info("Using C extension for midstate speedup. Good!")
 except ImportError:
+  try:
+    from midstatec.midstatec import test as midstateTest, midstate as calculateMidstate
+    if not midstateTest():
+      log.warning("midstate library didn't pass self test!")
+      raise ImportError("midstatec not usable")
+    log.info("Using C extension for midstate speedup. Good!")
+  except ImportError:
     log.info("C extension for midstate not available. Using default implementation instead.")
     try:    
-        from midstate import calculateMidstate
+      from midstate import calculateMidstate
     except ImportError:
-        calculateMidstate = None
-        log.exception("No midstate generator available. Some old miners won't work properly.")
+      calculateMidstate = None
+      log.exception("No midstate generator available. Some old miners won't work properly.")
 
 class Job(object):
     def __init__(self):

--- a/mining_libs/utils.py
+++ b/mining_libs/utils.py
@@ -7,6 +7,9 @@ from twisted.web import client
 import stratum.logger
 log = stratum.logger.get_logger('proxy')
 
+def StratumConnectionException(Exception):
+    pass
+
 def show_message(msg):
     '''Repeatedly displays the message received from
     the server.'''

--- a/mining_libs/version.py
+++ b/mining_libs/version.py
@@ -1,2 +1,2 @@
 # last stable: 1.5.5
-VERSION='1.5.6'
+VERSION='1.5.7'

--- a/mining_libs/version.py
+++ b/mining_libs/version.py
@@ -1,2 +1,2 @@
 # last stable: 1.5.5
-VERSION='1.5.7'
+VERSION='1.5.10'

--- a/mining_proxy.py
+++ b/mining_proxy.py
@@ -26,6 +26,7 @@ import socket
 def parse_args():
     parser = argparse.ArgumentParser(description='This proxy allows you to run getwork-based miners against Stratum mining pool.')
     parser.add_argument('-n', '--name', dest='name', type=str, default='stratum-mining-proxy', help='Process name')
+    parser.add_argument('-rxn2', '--randomize-extranonce2', dest='rxn2', action='store_true', help='Whether to randomize extranonce2')
     parser.add_argument('-o', '--host', dest='host', type=str, default='stratum.bitcoin.cz', help='Hostname of Stratum mining pool')
     parser.add_argument('-p', '--port', dest='port', type=int, default=3333, help='Port of Stratum mining pool')
     parser.add_argument('-sh', '--stratum-host', dest='stratum_host', type=str, default='0.0.0.0', help='On which network interface listen for stratum miners. Use "localhost" for listening on internal IP only.')
@@ -222,6 +223,7 @@ def main(args):
     
     job_registry = jobs.JobRegistry(f, cmd=args.blocknotify_cmd, scrypt_target=args.scrypt_target,
                    no_midstate=args.no_midstate, real_target=args.real_target, use_old_target=args.old_target)
+    job_registry.randomize_extranonce2 = args.rxn2
     client_service.ClientMiningService.job_registry = job_registry
     client_service.ClientMiningService.reset_timeout()
     

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ args = {
         'midstate', 
         ['midstatec/midstatemodule.c'],
         include_dirs=['/usr/include/python2.7'],
-        extra_compile_args=['-march=native', '-Wall', '-funroll-all-loops', '-O3', '-fstrict-aliasing', '-Wall', '-std=c99',  '-fPIC', '-shared'],
+        extra_compile_args=['-D_FORTIFY_SOURCE=2', '-march=native', '-Wall', '-funroll-all-loops', '-O3', '-fstrict-aliasing', '-std=c99',  '-fPIC', '-shared', '-fstack-protector', '--param=ssp-buffer-size=4', '-Wformat', '-Werror=format-security'],
         libraries=['python2.7'],
-        extra_link_args=['-Wl,-O1', '-Wl,--as-needed']
+        extra_link_args=['-Wl,-O1', '-Wl,--as-needed', '-Wl,-z,relro']
         )
       ],
     'py_modules': ['mining_libs.client_service', 'mining_libs.getwork_listener',
@@ -33,7 +33,7 @@ args = {
                    'mining_libs.multicast_responder', 'mining_libs.stratum_listener',
                    'mining_libs.utils', 'mining_libs.version', 'mining_libs.worker_registry',
                    'midstatec.midstatec'],
-    'install_requires': ['setuptools>=0.6c11', 'twisted>=12.2.0', 'stratum>=0.2.15', 'argparse'],
+    'install_requires': ['setuptools>=0.6c11', 'twisted>=12.2.0', 'stratum>=0.2.15', 'argparse', 'setproctitle'],
     'scripts': ['mining_proxy.py'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from distribute_setup import use_setuptools
 use_setuptools()
 
-from setuptools import setup
+from setuptools import setup, Extension
 import sys, os
 try:
     import py2exe
@@ -18,10 +18,21 @@ args = {
     'author': 'slush',
     'author_email': 'slush@satoshilabs.com',
     'url': 'http://mining.bitcoin.cz/stratum-mining/',
+    'ext_modules': [
+      Extension(
+        'midstate', 
+        ['midstatec/midstatemodule.c'],
+        include_dirs=['/usr/include/python2.7'],
+        extra_compile_args=['-march=native', '-Wall', '-funroll-all-loops', '-O3', '-fstrict-aliasing', '-Wall', '-std=c99',  '-fPIC', '-shared'],
+        libraries=['python2.7'],
+        extra_link_args=['-Wl,-O1', '-Wl,--as-needed']
+        )
+      ],
     'py_modules': ['mining_libs.client_service', 'mining_libs.getwork_listener',
                    'mining_libs.jobs', 'mining_libs.midstate',
                    'mining_libs.multicast_responder', 'mining_libs.stratum_listener',
-                   'mining_libs.utils', 'mining_libs.version', 'mining_libs.worker_registry'],
+                   'mining_libs.utils', 'mining_libs.version', 'mining_libs.worker_registry',
+                   'midstatec.midstatec'],
     'install_requires': ['setuptools>=0.6c11', 'twisted>=12.2.0', 'stratum>=0.2.15', 'argparse'],
     'scripts': ['mining_proxy.py'],
 }


### PR DESCRIPTION
MidstateC extension module now installs with both
```bash
python setup.py install
```
and via *dpkg* mechanism.
Confer _README_.