### PR TITLE
Fix errors in setup.py and getwork_listener.py

### DIFF
--- a/mining_libs/getwork_listener.py
+++ b/mining_libs/getwork_listener.py
@@ -119,7 +119,7 @@ class Root(Resource):
         else:
             request.setHeader('x-long-polling', '/lp')
             
-        request.setHeader('x-roll-ntime', 1)
+        request.setHeader('x-roll-ntime', "1")
         
     def _on_lp_broadcast(self, _, request):        
         try:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from distribute_setup import use_setuptools
-use_setuptools()
-
 from setuptools import setup, Extension
 import sys, os
 try:


### PR DESCRIPTION
Wasn't able to install under virtualenv, fixed setup.py since distribute and setuptools have merged

When running the proxy an error was raised, passing a string instead of an int to the Resource.setHeader function fixed the issue